### PR TITLE
Use Rust Cache Action to speed up builds.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - uses: Swatinem/rust-cache@v1
     - name: Build
       run: |
         cargo build


### PR DESCRIPTION
Fixes issue #5.